### PR TITLE
Replace static→instance copy ritual with applyStatics helper

### DIFF
--- a/src/nodes/damage-effect.ts
+++ b/src/nodes/damage-effect.ts
@@ -1,5 +1,5 @@
 import {Task} from 'vroum'
-import {html, randomIntFromInterval} from '../utils'
+import {applyStatics, html, randomIntFromInterval} from '../utils'
 import {AudioPlayer} from './audio'
 import {Character} from './character'
 import {logCombat, CombatEventType} from '../combatlog'
@@ -7,12 +7,10 @@ import {getFctContainer} from '../components/floating-combat-text'
 
 /**
  * Base class for all damage effects (attacks from any character to any character).
- * Subclasses declare static balance fields; the constructor copies them to instance
- * fields so balance updates only affect newly created attacks (canonical source: statics).
+ * Subclasses declare static balance fields; construction snapshots them onto the
+ * instance so balance edits only affect newly spawned attacks.
  */
 export class DamageEffect extends Task {
-	delay = 0
-	interval = 1000
 	duration = 0
 	repeat = Infinity
 
@@ -34,14 +32,7 @@ export class DamageEffect extends Task {
 
 	constructor(public attacker: Character) {
 		super(attacker)
-		const c = this.constructor as typeof DamageEffect
-		this.delay = c.delay
-		this.interval = c.interval
-		this.sound = c.sound
-		this.name = c.name
-		this.minDamage = c.minDamage
-		this.maxDamage = c.maxDamage
-		this.eventType = c.eventType
+		applyStatics(this, 'delay', 'interval', 'sound', 'name', 'minDamage', 'maxDamage', 'eventType')
 	}
 
 	damage() {

--- a/src/nodes/dot.ts
+++ b/src/nodes/dot.ts
@@ -1,15 +1,14 @@
 import {Task} from 'vroum'
 import {getFctContainer} from '../components/floating-combat-text'
-import {log, randomIntFromInterval} from '../utils'
+import {applyStatics, log, randomIntFromInterval} from '../utils'
 import {Character} from './character'
 import {AudioPlayer} from './audio'
 
 /**
- * Base class for all Damage over Time effects
- * DoTs attach to the target character and apply damage periodically
+ * Base class for all Damage over Time effects.
+ * DoTs attach to the target character and apply damage periodically.
  */
 export class DoT extends Task {
-	// Instance properties
 	name = 'Periodic Damage'
 	minDamage = 0
 	maxDamage = 0
@@ -17,14 +16,12 @@ export class DoT extends Task {
 	repeat = 5
 	sound = ''
 
-	// Required for compatibility with HOT effects in the Character.effects Set
+	/** Kept so HOT/DoT can share Character.effects without a type union check. */
 	heal = 0
 
-	// Store original caster for damage attribution
 	casterName = ''
 	casterId = ''
 
-	// Static properties for effect definitions
 	static name = 'Periodic Damage'
 	static minDamage = 0
 	static maxDamage = 0
@@ -33,21 +30,11 @@ export class DoT extends Task {
 	static sound = ''
 
 	constructor(
-		public parent: Character, // The target character this DoT is attached to
-		public caster: Character, // The character who applied this DoT
+		public parent: Character,
+		public caster: Character,
 	) {
-		super(parent) // Parent is the target
-
-		// Copy static properties to instance
-		const constructor = this.constructor as typeof DoT
-		this.name = constructor.name
-		this.minDamage = constructor.minDamage
-		this.maxDamage = constructor.maxDamage
-		this.interval = constructor.interval
-		this.repeat = constructor.repeat
-		this.sound = constructor.sound
-
-		// Store caster info for attribution
+		super(parent)
+		applyStatics(this, 'name', 'minDamage', 'maxDamage', 'interval', 'repeat', 'sound')
 		this.casterName = caster.constructor.name
 		this.casterId = caster.id
 	}

--- a/src/nodes/hot.ts
+++ b/src/nodes/hot.ts
@@ -1,6 +1,6 @@
 import {Task} from 'vroum'
 import {fct} from '../components/floating-combat-text'
-import {log} from '../utils'
+import {applyStatics, log} from '../utils'
 import {Character} from './character'
 import {logCombat} from '../combatlog'
 
@@ -10,8 +10,14 @@ export class HOT extends Task {
 	interval = 3000
 	repeat = 5
 
+	static name = 'Periodic Heal'
+	static heal = 0
+	static interval = 3000
+	static repeat = 5
+
 	constructor(public parent: Character) {
 		super(parent)
+		applyStatics(this, 'name', 'heal', 'interval', 'repeat')
 	}
 
 	mount() {

--- a/src/nodes/spell.ts
+++ b/src/nodes/spell.ts
@@ -2,7 +2,7 @@ import {Task} from 'vroum'
 import {AudioPlayer} from './audio'
 import {GlobalCooldown} from './global-cooldown'
 import {fct} from '../components/floating-combat-text'
-import {log, naturalizeNumber} from '../utils'
+import {applyStatics, log, naturalizeNumber} from '../utils'
 import {Player} from './player'
 import {GameLoop} from './game-loop'
 import {logCombat} from '../combatlog'
@@ -10,27 +10,20 @@ import {logCombat} from '../combatlog'
 export class Spell extends Task {
 	repeat = 1
 
-	// Instance properties
 	name = ''
 	cost = 0
 	heal = 0
-	// We'll use castTime instead of delay to avoid conflicts with Task API
 
-	// Static properties for spell definitions
 	static name = ''
 	static cost = 0
 	static heal = 0
-	static castTime = 0 // Cast time in milliseconds
+	/** Cast time in ms. Mirrored onto Task.delay at construction. */
+	static castTime = 0
 
 	constructor(public parent: Player) {
 		super(parent)
-
-		// Copy static properties to instance
-		const constructor = this.constructor as typeof Spell
-		this.name = constructor.name || this.name
-		this.cost = constructor.cost || this.cost
-		this.heal = constructor.heal || this.heal
-		this.delay = constructor.castTime || 0 // Set Task.delay from castTime
+		applyStatics(this, 'name', 'cost', 'heal')
+		this.delay = (this.constructor as typeof Spell).castTime
 	}
 
 	mount() {

--- a/src/nodes/spells.ts
+++ b/src/nodes/spells.ts
@@ -1,7 +1,6 @@
 import {Spell} from './spell'
 import {HOT} from './hot'
 import {AudioPlayer} from './audio'
-import {Character} from './character'
 
 export class Heal extends Spell {
 	static name = 'Heal'
@@ -45,13 +44,4 @@ class RenewHOT extends HOT {
 	static heal = 30
 	static interval = 2000
 	static repeat = 5
-
-	constructor(parent: Character) {
-		super(parent)
-		// Copy static properties to instance
-		this.name = RenewHOT.name
-		this.heal = RenewHOT.heal
-		this.interval = RenewHOT.interval
-		this.repeat = RenewHOT.repeat
-	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,19 @@ export function createId() {
 }
 
 /**
+ * Copy named static fields from `instance.constructor` onto `instance`.
+ * Lets subclasses act as pure data templates while preserving the
+ * snapshot-at-construction semantics the balance UI relies on.
+ */
+export function applyStatics<T extends object, K extends keyof T>(instance: T, ...keys: K[]) {
+	const Ctor = instance.constructor as unknown as Record<string, unknown>
+	for (const k of keys) {
+		const v = Ctor[k as string]
+		if (v !== undefined) (instance as Record<string, unknown>)[k as string] = v
+	}
+}
+
+/**
  * Format a timestamp for display
  */
 export function formatTimestamp(timestamp: number): string {


### PR DESCRIPTION
The base classes for Spell, DamageEffect, DoT, and HOT each repeated a
5–7 line constructor that mirrored static config onto the instance.
RenewHOT had its own inline copy of the same shape. One small helper in
utils.ts captures the pattern, so subclasses can be pure data: see
RenewHOT shedding its constructor entirely.

Behavior is unchanged — balance edits still only affect newly spawned
attacks (the snapshot semantics live in applyStatics now).